### PR TITLE
[#7] added KeyedGrouping to the Gradoop Benchmark

### DIFF
--- a/src/main/java/org/gradoop/benchmarks/keyedgrouping/package-info.java
+++ b/src/main/java/org/gradoop/benchmarks/keyedgrouping/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains example Gradoop programs that can be executed on a Flink cluster.
+ */
+package org.gradoop.benchmarks.keyedgrouping;


### PR DESCRIPTION
* added the KeyedGrouping to the Benchmark 

* simplified the controls: removed the vertex/edge result keys, now every aggregator function uses the default ones (count, max, min, mean)

* added a function checkIfEnoughKeys(String aggs, String keys) which makes sure that every given max, min or average aggregation gets a propertyKey to get the numerical values from

* count aggregation now do not needs a propertyKey

* applied all these changes on the Grouping Benchmark as well

* tested both Benchmarks with the ldbc_1 graph