### PR TITLE
Add keyed grouping benchmark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
         <license.licenseName>apache_v2</license.licenseName>
 
-        <dep.gradoop.version>0.5.1</dep.gradoop.version>
+        <dep.gradoop.version>0.6.0-SNAPSHOT</dep.gradoop.version>
         <dep.flink.version>1.7.2</dep.flink.version>
         <dep.commons-cli.version>1.4</dep.commons-cli.version>
 
@@ -65,6 +65,12 @@
             <groupId>org.gradoop</groupId>
             <artifactId>gradoop-temporal</artifactId>
             <version>${dep.gradoop.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gradoop</groupId>
+            <artifactId>gradoop-capf</artifactId>
+            <version>0.5.1</version>
         </dependency>
 
         <!-- Apache Flink dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <license.licenseName>apache_v2</license.licenseName>
 
         <dep.gradoop.version>0.6.0-SNAPSHOT</dep.gradoop.version>
+        <dep.gradoop-capf.version>0.5.1</dep.gradoop-capf.version>
         <dep.flink.version>1.7.2</dep.flink.version>
         <dep.commons-cli.version>1.4</dep.commons-cli.version>
 
@@ -70,7 +71,7 @@
         <dependency>
             <groupId>org.gradoop</groupId>
             <artifactId>gradoop-capf</artifactId>
-            <version>0.5.1</version>
+            <version>${dep.gradoop-capf.version}</version>
         </dependency>
 
         <!-- Apache Flink dependencies -->

--- a/src/main/java/org/gradoop/benchmarks/cypher/CAPFBenchmark.java
+++ b/src/main/java/org/gradoop/benchmarks/cypher/CAPFBenchmark.java
@@ -23,6 +23,7 @@ import org.gradoop.benchmarks.AbstractRunner;
 import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.model.impl.epgm.GraphCollection;
 import org.gradoop.flink.model.impl.epgm.LogicalGraph;
+import org.gradoop.flink.model.impl.operators.cypher.capf.query.CAPFQuery;
 import org.gradoop.flink.model.impl.operators.cypher.capf.result.CAPFQueryResult;
 
 import java.io.File;
@@ -113,7 +114,7 @@ public class CAPFBenchmark extends AbstractRunner {
 
     System.out.println(QUERY);
     // execute cypher with or without statistics
-    CAPFQueryResult result = graph.cypher(QUERY);
+    CAPFQueryResult result = new CAPFQuery(QUERY, getExecutionEnvironment()).execute(graph);
 
     if (result.containsGraphs()) {
       collection = result.getGraphs();

--- a/src/main/java/org/gradoop/benchmarks/grouping/KeyedGroupingBenchmark.java
+++ b/src/main/java/org/gradoop/benchmarks/grouping/KeyedGroupingBenchmark.java
@@ -224,31 +224,26 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
 
       vertexAggregateFunctions = Arrays.asList(
         new Count("count"),
-        new MinTime("min", DIMENSION, TimeDimension.Field.FROM));
+        new MinTime("minTime", DIMENSION, TimeDimension.Field.FROM));
 
       edgeAggregateFunctions = Arrays.asList(new Count("count"));
       break;
 
     case 3:
-      vertexKeys = Arrays.asList(
-        GroupingKeys.label(),
-        TemporalGroupingKeys.timeStamp(
-          DIMENSION,
-          TimeDimension.Field.TO,
-          ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH));
+      vertexKeys = Arrays.asList(GroupingKeys.label());
 
       edgeKeys = Arrays.asList(
         GroupingKeys.label(),
         TemporalGroupingKeys.timeStamp(
           DIMENSION,
-          TimeDimension.Field.TO,
+          TimeDimension.Field.FROM,
           ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH));
 
       vertexAggregateFunctions = Arrays.asList(new Count("count"));
 
       edgeAggregateFunctions = Arrays.asList(
         new Count("count"),
-        new MaxTime("maxTime", DIMENSION, TimeDimension.Field.TO));
+        new MaxTime("maxTime", DIMENSION, TimeDimension.Field.FROM));
       break;
 
     default:

--- a/src/main/java/org/gradoop/benchmarks/grouping/KeyedGroupingBenchmark.java
+++ b/src/main/java/org/gradoop/benchmarks/grouping/KeyedGroupingBenchmark.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2014 - 2020 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.gradoop.benchmarks.grouping;
 
 import org.apache.commons.cli.CommandLine;
@@ -40,37 +56,56 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A dedicated program for the evaluation of the {@link KeyedGrouping} operator both on EPGM and TPGM graphs.
+ */
 public class KeyedGroupingBenchmark extends AbstractRunner {
 
   /**
    * Option to declare path to input graph
    */
   private static final String OPTION_INPUT_PATH = "i";
-
   /**
    * Option to declare path to output graph
    */
   private static final String OPTION_OUTPUT_PATH = "o";
-
+  /**
+   * Option to declare path to statistics file
+   */
+  private static final String OPTION_STATISTICS_PATH = "s";
+  /**
+   * Option to specify keyed grouping config
+   */
   private static final String OPTION_CONFIG = "c";
   /**
-   * Path to CSV log file
+   * Option to specify whether the benchmark operates on a temporal graph or not
    */
-  private static final String OPTION_STATISTICS_PATH = "csv";
-
   private static final String OPTION_TEMPORAL = "t";
-
+  /**
+   * Index of the selected config
+   */
   private static int SELECTED_CONFIG;
-
+  /**
+   * Path to the directory that contains {@link CSVDataSource} or {@link TemporalCSVDataSource} compatible
+   * graph data
+   */
   private static String INPUT_PATH;
-
+  /**
+   * Path to the directory the resulting graph data will be written to
+   */
   private static String OUTPUT_PATH;
-
+  /**
+   * Path to the statistics csv file
+   */
   private static String STATISTICS_PATH;
-
+  /**
+   * Flag which determines whether keyed grouping is applied to TPGM or EPGM graphs
+   */
   private static boolean IS_TEMPORAL;
-
-  private static TimeDimension DIMENSION = TimeDimension.VALID_TIME;
+  /**
+   * {@link TimeDimension} that is considered in the context of this benchmark.
+   */
+  private static final TimeDimension DIMENSION = TimeDimension.VALID_TIME;
 
   static {
     OPTIONS.addRequiredOption(OPTION_INPUT_PATH, "input", true, "Path to input csv directory");
@@ -80,7 +115,15 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
     OPTIONS.addOption(OPTION_TEMPORAL, "temporal", false, "Apply temporal keyed grouping to input graph");
   }
 
-
+  /**
+   * Main program to run the benchmark.
+   * <p>
+   * Example: {@code $ /path/to/flink run -c org.gradoop.benchmarks.grouping.KeyedGroupingBenchmark
+   * /path/to/gradoop-benchmarks.jar -i hdfs:///graph -o hdfs:///output -s results.csv -c 1 --temporal}
+   *
+   * @param args program arguments
+   * @throws Exception in case of error
+   */
   public static void main(String[] args) throws Exception {
     CommandLine cmd = parseArguments(args, AggregationBenchmark.class.getName());
 
@@ -94,6 +137,7 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
     ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
     if (IS_TEMPORAL) {
+      // Apply keyed grouping operation on TPGM graph
       TemporalGradoopConfig cfg = TemporalGradoopConfig.createConfig(env);
 
       TemporalDataSource source = new TemporalCSVDataSource(INPUT_PATH, cfg);
@@ -102,8 +146,10 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
       TemporalGraph groupedGraph = graph.callForGraph(getTPGMGroupingConfig(SELECTED_CONFIG));
 
       TemporalCSVDataSink sink = new TemporalCSVDataSink(OUTPUT_PATH, cfg);
-      sink.write(groupedGraph);
+      sink.write(groupedGraph, true);
+
     } else {
+      // Apply keyed grouping operation on EPGM graph
       GradoopFlinkConfig cfg = GradoopFlinkConfig.createConfig(env);
 
       DataSource source = new CSVDataSource(INPUT_PATH, cfg);
@@ -112,7 +158,7 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
       LogicalGraph groupedGraph = graph.callForGraph(getEPGMGroupingConfig(SELECTED_CONFIG));
 
       CSVDataSink sink = new CSVDataSink(OUTPUT_PATH, cfg);
-      sink.write(groupedGraph);
+      sink.write(groupedGraph, true);
     }
 
     env.execute(KeyedGrouping.class.getSimpleName() + " - P: " + env.getParallelism());
@@ -120,40 +166,56 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
     writeStatistics(env);
   }
 
+  /**
+   * Returns a specific {@link KeyedGrouping} object which will be applied on a {@link TemporalGraph}.
+   * <p>
+   * This method is meant to be easily extendable in order to provide multiple keyed grouping configurations.
+   * @param select the selected keyed grouping configuration
+   * @return the selected {@link KeyedGrouping} object
+   */
   private static KeyedGrouping<
     TemporalGraphHead,
     TemporalVertex,
     TemporalEdge,
     TemporalGraph,
     TemporalGraphCollection> getTPGMGroupingConfig(int select) {
+
     List<KeyFunction<TemporalVertex, ?>> vertexKeys;
     List<KeyFunction<TemporalEdge, ?>> edgeKeys;
     List<AggregateFunction> vertexAggregateFunctions;
     List<AggregateFunction> edgeAggregateFunctions;
 
     switch (select) {
-      case 1:
-        vertexKeys = Arrays.asList(
-          GroupingKeys.label(),
-          TemporalGroupingKeys.timeStamp(DIMENSION, TimeDimension.Field.FROM, ChronoField.ALIGNED_WEEK_OF_YEAR));
-        edgeKeys = Arrays.asList(
-          GroupingKeys.label(),
-          TemporalGroupingKeys.timeStamp(DIMENSION, TimeDimension.Field.FROM, ChronoField.ALIGNED_WEEK_OF_YEAR));
+    case 1:
+      vertexKeys = Arrays.asList(
+        GroupingKeys.label(),
+        TemporalGroupingKeys.timeStamp(DIMENSION, TimeDimension.Field.FROM, ChronoField.ALIGNED_WEEK_OF_YEAR));
 
-        vertexAggregateFunctions = Arrays.asList(
-          new Count("count")
-        );
+      edgeKeys = Arrays.asList(
+        GroupingKeys.label(),
+        TemporalGroupingKeys.timeStamp(DIMENSION, TimeDimension.Field.FROM, ChronoField.ALIGNED_WEEK_OF_YEAR));
 
-        edgeAggregateFunctions = Arrays.asList(
-          new Count("count")
-        );
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported config: " + select);
+      vertexAggregateFunctions = Arrays.asList(
+        new Count("count")
+      );
+
+      edgeAggregateFunctions = Arrays.asList(
+        new Count("count")
+      );
+      break;
+    default:
+      throw new IllegalArgumentException("Unsupported config: " + select);
     }
     return new KeyedGrouping<>(vertexKeys, vertexAggregateFunctions, edgeKeys, edgeAggregateFunctions);
   }
 
+  /**
+   * Returns a specific {@link KeyedGrouping} object which will be applied on a {@link LogicalGraph}.
+   * <p>
+   * This method is meant to be easily extendable in order to provide multiple keyed grouping configurations.
+   * @param select the selected keyed grouping configuration
+   * @return the selected {@link KeyedGrouping} object
+   */
   private static KeyedGrouping<
     EPGMGraphHead,
     EPGMVertex,
@@ -167,40 +229,42 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
     List<AggregateFunction> edgeAggregateFunctions;
 
     switch (select) {
-      case 1:
-        vertexKeys = Collections.singletonList(GroupingKeys.label());
-        edgeKeys = Collections.singletonList(GroupingKeys.label());
-        vertexAggregateFunctions = Collections.singletonList(new Count("count"));
-        edgeAggregateFunctions = Collections.singletonList(new Count("count"));
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported config: " + select);
+    case 1:
+      vertexKeys = Collections.singletonList(GroupingKeys.label());
+      edgeKeys = Collections.singletonList(GroupingKeys.label());
+      vertexAggregateFunctions = Collections.singletonList(new Count("count"));
+      edgeAggregateFunctions = Collections.singletonList(new Count("count"));
+      break;
+    default:
+      throw new IllegalArgumentException("Unsupported config: " + select);
     }
 
     return new KeyedGrouping<>(vertexKeys, vertexAggregateFunctions, edgeKeys, edgeAggregateFunctions);
   }
 
+  /**
+   * Read values from the given {@link CommandLine} object
+   *
+   * @param cmd the {@link CommandLine} object
+   */
   private static void readCMDArguments(CommandLine cmd) {
-    // read input output paths
     INPUT_PATH = cmd.getOptionValue(OPTION_INPUT_PATH);
     OUTPUT_PATH = cmd.getOptionValue(OPTION_OUTPUT_PATH);
     STATISTICS_PATH = cmd.getOptionValue(OPTION_STATISTICS_PATH);
-
-    String config = cmd.getOptionValue(OPTION_CONFIG);
-    SELECTED_CONFIG = Integer.parseInt(config);
-
+    SELECTED_CONFIG = Integer.parseInt(cmd.getOptionValue(OPTION_CONFIG));
     IS_TEMPORAL = cmd.hasOption(OPTION_TEMPORAL);
   }
 
   /**
-   * Method to create and add lines to a csv-file
+   * Method to create and add lines to a csv file which contains all necessary statistics about the
+   * {@link KeyedGrouping} operator.
    *
-   * @param env given ExecutionEnvironment
+   * @param env given {@link ExecutionEnvironment}
    * @throws IOException exception during file writing
    */
   private static void writeStatistics(ExecutionEnvironment env) throws IOException {
     String head = String
-      .format("%s|%s|%s|%s|%s",
+      .format("%s|%s|%s|%s|%s%n",
         "Parallelism",
         "dataset",
         "config",
@@ -208,7 +272,7 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
         "Runtime(s)");
 
     String tail = String
-      .format("%s|%s|%s|%s|%s",
+      .format("%s|%s|%s|%s|%s%n",
         env.getParallelism(),
         INPUT_PATH,
         SELECTED_CONFIG,

--- a/src/main/java/org/gradoop/benchmarks/grouping/KeyedGroupingBenchmark.java
+++ b/src/main/java/org/gradoop/benchmarks/grouping/KeyedGroupingBenchmark.java
@@ -1,0 +1,229 @@
+package org.gradoop.benchmarks.grouping;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.io.FileUtils;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.gradoop.benchmarks.AbstractRunner;
+import org.gradoop.benchmarks.tpgm.AggregationBenchmark;
+import org.gradoop.common.model.impl.pojo.EPGMEdge;
+import org.gradoop.common.model.impl.pojo.EPGMGraphHead;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
+import org.gradoop.flink.io.api.DataSource;
+import org.gradoop.flink.io.impl.csv.CSVDataSink;
+import org.gradoop.flink.io.impl.csv.CSVDataSource;
+import org.gradoop.flink.model.api.functions.AggregateFunction;
+import org.gradoop.flink.model.api.functions.KeyFunction;
+import org.gradoop.flink.model.impl.epgm.GraphCollection;
+import org.gradoop.flink.model.impl.epgm.LogicalGraph;
+import org.gradoop.flink.model.impl.operators.aggregation.functions.count.Count;
+import org.gradoop.flink.model.impl.operators.keyedgrouping.GroupingKeys;
+import org.gradoop.flink.model.impl.operators.keyedgrouping.KeyedGrouping;
+import org.gradoop.flink.util.GradoopFlinkConfig;
+import org.gradoop.temporal.io.api.TemporalDataSource;
+import org.gradoop.temporal.io.impl.csv.TemporalCSVDataSink;
+import org.gradoop.temporal.io.impl.csv.TemporalCSVDataSource;
+import org.gradoop.temporal.model.api.TimeDimension;
+import org.gradoop.temporal.model.impl.TemporalGraph;
+import org.gradoop.temporal.model.impl.TemporalGraphCollection;
+import org.gradoop.temporal.model.impl.operators.keyedgrouping.TemporalGroupingKeys;
+import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
+import org.gradoop.temporal.model.impl.pojo.TemporalGraphHead;
+import org.gradoop.temporal.model.impl.pojo.TemporalVertex;
+import org.gradoop.temporal.util.TemporalGradoopConfig;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.temporal.ChronoField;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class KeyedGroupingBenchmark extends AbstractRunner {
+
+  /**
+   * Option to declare path to input graph
+   */
+  private static final String OPTION_INPUT_PATH = "i";
+
+  /**
+   * Option to declare path to output graph
+   */
+  private static final String OPTION_OUTPUT_PATH = "o";
+
+  private static final String OPTION_CONFIG = "c";
+  /**
+   * Path to CSV log file
+   */
+  private static final String OPTION_STATISTICS_PATH = "csv";
+
+  private static final String OPTION_TEMPORAL = "t";
+
+  private static int SELECTED_CONFIG;
+
+  private static String INPUT_PATH;
+
+  private static String OUTPUT_PATH;
+
+  private static String STATISTICS_PATH;
+
+  private static boolean IS_TEMPORAL;
+
+  private static TimeDimension DIMENSION = TimeDimension.VALID_TIME;
+
+  static {
+    OPTIONS.addRequiredOption(OPTION_INPUT_PATH, "input", true, "Path to input csv directory");
+    OPTIONS.addRequiredOption(OPTION_OUTPUT_PATH, "output", true, "Path to output directory");
+    OPTIONS.addRequiredOption(OPTION_STATISTICS_PATH, "statistics", true, "Path to statistics csv file");
+    OPTIONS.addRequiredOption(OPTION_CONFIG, "config", true, "Select predefined configuration");
+    OPTIONS.addOption(OPTION_TEMPORAL, "temporal", false, "Apply temporal keyed grouping to input graph");
+  }
+
+
+  public static void main(String[] args) throws Exception {
+    CommandLine cmd = parseArguments(args, AggregationBenchmark.class.getName());
+
+    if (cmd == null) {
+      return;
+    }
+
+    // read cmd arguments
+    readCMDArguments(cmd);
+
+    ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+    if (IS_TEMPORAL) {
+      TemporalGradoopConfig cfg = TemporalGradoopConfig.createConfig(env);
+
+      TemporalDataSource source = new TemporalCSVDataSource(INPUT_PATH, cfg);
+      TemporalGraph graph = source.getTemporalGraph();
+
+      TemporalGraph groupedGraph = graph.callForGraph(getTPGMGroupingConfig(SELECTED_CONFIG));
+
+      TemporalCSVDataSink sink = new TemporalCSVDataSink(OUTPUT_PATH, cfg);
+      sink.write(groupedGraph);
+    } else {
+      GradoopFlinkConfig cfg = GradoopFlinkConfig.createConfig(env);
+
+      DataSource source = new CSVDataSource(INPUT_PATH, cfg);
+      LogicalGraph graph = source.getLogicalGraph();
+
+      LogicalGraph groupedGraph = graph.callForGraph(getEPGMGroupingConfig(SELECTED_CONFIG));
+
+      CSVDataSink sink = new CSVDataSink(OUTPUT_PATH, cfg);
+      sink.write(groupedGraph);
+    }
+
+    env.execute(KeyedGrouping.class.getSimpleName() + " - P: " + env.getParallelism());
+
+    writeStatistics(env);
+  }
+
+  private static KeyedGrouping<
+    TemporalGraphHead,
+    TemporalVertex,
+    TemporalEdge,
+    TemporalGraph,
+    TemporalGraphCollection> getTPGMGroupingConfig(int select) {
+    List<KeyFunction<TemporalVertex, ?>> vertexKeys;
+    List<KeyFunction<TemporalEdge, ?>> edgeKeys;
+    List<AggregateFunction> vertexAggregateFunctions;
+    List<AggregateFunction> edgeAggregateFunctions;
+
+    switch (select) {
+      case 1:
+        vertexKeys = Arrays.asList(
+          GroupingKeys.label(),
+          TemporalGroupingKeys.timeStamp(DIMENSION, TimeDimension.Field.FROM, ChronoField.ALIGNED_WEEK_OF_YEAR));
+        edgeKeys = Arrays.asList(
+          GroupingKeys.label(),
+          TemporalGroupingKeys.timeStamp(DIMENSION, TimeDimension.Field.FROM, ChronoField.ALIGNED_WEEK_OF_YEAR));
+
+        vertexAggregateFunctions = Arrays.asList(
+          new Count("count")
+        );
+
+        edgeAggregateFunctions = Arrays.asList(
+          new Count("count")
+        );
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported config: " + select);
+    }
+    return new KeyedGrouping<>(vertexKeys, vertexAggregateFunctions, edgeKeys, edgeAggregateFunctions);
+  }
+
+  private static KeyedGrouping<
+    EPGMGraphHead,
+    EPGMVertex,
+    EPGMEdge,
+    LogicalGraph,
+    GraphCollection> getEPGMGroupingConfig(int select) {
+
+    List<KeyFunction<EPGMVertex, ?>> vertexKeys;
+    List<KeyFunction<EPGMEdge, ?>> edgeKeys;
+    List<AggregateFunction> vertexAggregateFunctions;
+    List<AggregateFunction> edgeAggregateFunctions;
+
+    switch (select) {
+      case 1:
+        vertexKeys = Collections.singletonList(GroupingKeys.label());
+        edgeKeys = Collections.singletonList(GroupingKeys.label());
+        vertexAggregateFunctions = Collections.singletonList(new Count("count"));
+        edgeAggregateFunctions = Collections.singletonList(new Count("count"));
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported config: " + select);
+    }
+
+    return new KeyedGrouping<>(vertexKeys, vertexAggregateFunctions, edgeKeys, edgeAggregateFunctions);
+  }
+
+  private static void readCMDArguments(CommandLine cmd) {
+    // read input output paths
+    INPUT_PATH = cmd.getOptionValue(OPTION_INPUT_PATH);
+    OUTPUT_PATH = cmd.getOptionValue(OPTION_OUTPUT_PATH);
+    STATISTICS_PATH = cmd.getOptionValue(OPTION_STATISTICS_PATH);
+
+    String config = cmd.getOptionValue(OPTION_CONFIG);
+    SELECTED_CONFIG = Integer.parseInt(config);
+
+    IS_TEMPORAL = cmd.hasOption(OPTION_TEMPORAL);
+  }
+
+  /**
+   * Method to create and add lines to a csv-file
+   *
+   * @param env given ExecutionEnvironment
+   * @throws IOException exception during file writing
+   */
+  private static void writeStatistics(ExecutionEnvironment env) throws IOException {
+    String head = String
+      .format("%s|%s|%s|%s|%s",
+        "Parallelism",
+        "dataset",
+        "config",
+        "temporal",
+        "Runtime(s)");
+
+    String tail = String
+      .format("%s|%s|%s|%s|%s",
+        env.getParallelism(),
+        INPUT_PATH,
+        SELECTED_CONFIG,
+        IS_TEMPORAL,
+        env.getLastJobExecutionResult().getNetRuntime(TimeUnit.SECONDS));
+
+    File f = new File(STATISTICS_PATH);
+    if (f.exists() && !f.isDirectory()) {
+      FileUtils.writeStringToFile(f, tail, true);
+    } else {
+      PrintWriter writer = new PrintWriter(STATISTICS_PATH, "UTF-8");
+      writer.print(head);
+      writer.print(tail);
+      writer.close();
+    }
+  }
+
+}

--- a/src/main/java/org/gradoop/benchmarks/grouping/KeyedGroupingBenchmark.java
+++ b/src/main/java/org/gradoop/benchmarks/grouping/KeyedGroupingBenchmark.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradoop.benchmarks.grouping;
 
 import org.apache.commons.cli.CommandLine;
@@ -41,6 +40,8 @@ import org.gradoop.temporal.io.impl.csv.TemporalCSVDataSource;
 import org.gradoop.temporal.model.api.TimeDimension;
 import org.gradoop.temporal.model.impl.TemporalGraph;
 import org.gradoop.temporal.model.impl.TemporalGraphCollection;
+import org.gradoop.temporal.model.impl.operators.aggregation.functions.MaxTime;
+import org.gradoop.temporal.model.impl.operators.aggregation.functions.MinTime;
 import org.gradoop.temporal.model.impl.operators.keyedgrouping.TemporalGroupingKeys;
 import org.gradoop.temporal.model.impl.pojo.TemporalEdge;
 import org.gradoop.temporal.model.impl.pojo.TemporalGraphHead;
@@ -131,7 +132,6 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
       return;
     }
 
-    // read cmd arguments
     readCMDArguments(cmd);
 
     ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
@@ -170,6 +170,7 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
    * Returns a specific {@link KeyedGrouping} object which will be applied on a {@link TemporalGraph}.
    * <p>
    * This method is meant to be easily extendable in order to provide multiple keyed grouping configurations.
+   *
    * @param select the selected keyed grouping configuration
    * @return the selected {@link KeyedGrouping} object
    */
@@ -189,23 +190,71 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
     case 1:
       vertexKeys = Arrays.asList(
         GroupingKeys.label(),
-        TemporalGroupingKeys.timeStamp(DIMENSION, TimeDimension.Field.FROM, ChronoField.ALIGNED_WEEK_OF_YEAR));
+        TemporalGroupingKeys.timeStamp(
+          DIMENSION,
+          TimeDimension.Field.FROM,
+          ChronoField.ALIGNED_WEEK_OF_YEAR));
 
       edgeKeys = Arrays.asList(
         GroupingKeys.label(),
-        TemporalGroupingKeys.timeStamp(DIMENSION, TimeDimension.Field.FROM, ChronoField.ALIGNED_WEEK_OF_YEAR));
+        TemporalGroupingKeys.timeStamp(
+          DIMENSION,
+          TimeDimension.Field.FROM,
+          ChronoField.ALIGNED_WEEK_OF_YEAR));
+
+      vertexAggregateFunctions = Arrays.asList(new Count("count"));
+
+      edgeAggregateFunctions = Arrays.asList(new Count("count"));
+      break;
+
+    case 2:
+      vertexKeys = Arrays.asList(
+        GroupingKeys.label(),
+        TemporalGroupingKeys.timeStamp(
+          DIMENSION,
+          TimeDimension.Field.FROM,
+          ChronoField.ALIGNED_WEEK_OF_MONTH));
+
+      edgeKeys = Arrays.asList(
+        GroupingKeys.label(),
+        TemporalGroupingKeys.timeStamp(
+          DIMENSION,
+          TimeDimension.Field.FROM,
+          ChronoField.ALIGNED_WEEK_OF_MONTH));
 
       vertexAggregateFunctions = Arrays.asList(
-        new Count("count")
-      );
+        new Count("count"),
+        new MinTime("min", DIMENSION, TimeDimension.Field.FROM));
+
+      edgeAggregateFunctions = Arrays.asList(new Count("count"));
+      break;
+
+    case 3:
+      vertexKeys = Arrays.asList(
+        GroupingKeys.label(),
+        TemporalGroupingKeys.timeStamp(
+          DIMENSION,
+          TimeDimension.Field.TO,
+          ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH));
+
+      edgeKeys = Arrays.asList(
+        GroupingKeys.label(),
+        TemporalGroupingKeys.timeStamp(
+          DIMENSION,
+          TimeDimension.Field.TO,
+          ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH));
+
+      vertexAggregateFunctions = Arrays.asList(new Count("count"));
 
       edgeAggregateFunctions = Arrays.asList(
-        new Count("count")
-      );
+        new Count("count"),
+        new MaxTime("maxTime", DIMENSION, TimeDimension.Field.TO));
       break;
+
     default:
       throw new IllegalArgumentException("Unsupported config: " + select);
     }
+
     return new KeyedGrouping<>(vertexKeys, vertexAggregateFunctions, edgeKeys, edgeAggregateFunctions);
   }
 
@@ -213,6 +262,7 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
    * Returns a specific {@link KeyedGrouping} object which will be applied on a {@link LogicalGraph}.
    * <p>
    * This method is meant to be easily extendable in order to provide multiple keyed grouping configurations.
+   *
    * @param select the selected keyed grouping configuration
    * @return the selected {@link KeyedGrouping} object
    */
@@ -235,6 +285,14 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
       vertexAggregateFunctions = Collections.singletonList(new Count("count"));
       edgeAggregateFunctions = Collections.singletonList(new Count("count"));
       break;
+
+    case 2:
+      vertexKeys = Collections.singletonList(GroupingKeys.nothing());
+      edgeKeys = Collections.singletonList(GroupingKeys.label());
+      vertexAggregateFunctions = Collections.singletonList(new Count("count"));
+      edgeAggregateFunctions = Collections.singletonList(new Count("count"));
+      break;
+
     default:
       throw new IllegalArgumentException("Unsupported config: " + select);
     }
@@ -289,5 +347,4 @@ public class KeyedGroupingBenchmark extends AbstractRunner {
       writer.close();
     }
   }
-
 }


### PR DESCRIPTION
This PR adds a new benchmark class ´KeyedGroupingBenchmark` which is supposed to be used to evaluate the KeyedGrouping operator. The program supports grouping on logical graphs as well as on temporal graphs.

Before this can be merged, the following things must be checked:
  - the benchmark runs on a real flink cluster, not just on a local one
  - the provided configurations suffice
  - the code conforms to the code style

resolves #7 